### PR TITLE
修改滚动条两端的按钮独立处理鼠标响应

### DIFF
--- a/DuiLib/Control/UIScrollBar.cpp
+++ b/DuiLib/Control/UIScrollBar.cpp
@@ -683,10 +683,34 @@ namespace DuiLib
 						Invalidate();
 					}
 				}
+				else if (0 != (m_uButton1State & UISTATE_HOT))
+				{
+					if( !::PtInRect(&m_rcButton1, event.ptMouse) ) {
+						m_uButton1State &= ~UISTATE_HOT;
+						Invalidate();
+					}
+				}
+				else if (0 != (m_uButton2State & UISTATE_HOT))
+				{
+					if( !::PtInRect(&m_rcButton2, event.ptMouse) ) {
+						m_uButton2State &= ~UISTATE_HOT;
+						Invalidate();
+					}
+				}
 				else {
 					if( !IsEnabled() ) return;
 					if( ::PtInRect(&m_rcThumb, event.ptMouse) ) {
 						m_uThumbState |= UISTATE_HOT;
+						Invalidate();
+					}
+					if( ::PtInRect(&m_rcButton1, event.ptMouse) ) 
+					{
+						m_uButton1State |= UISTATE_HOT;
+						Invalidate();
+					}
+					if( ::PtInRect(&m_rcButton2, event.ptMouse) ) 
+					{
+						m_uButton2State |= UISTATE_HOT;
 						Invalidate();
 					}
 				}
@@ -767,8 +791,8 @@ namespace DuiLib
 		if( event.Type == UIEVENT_MOUSEENTER )
 		{
 			if( IsEnabled() ) {
-				m_uButton1State |= UISTATE_HOT;
-				m_uButton2State |= UISTATE_HOT;
+				if( ::PtInRect(&m_rcButton1, event.ptMouse) ) m_uButton1State |= UISTATE_HOT;
+				if( ::PtInRect(&m_rcButton2, event.ptMouse) ) m_uButton2State |= UISTATE_HOT;
 				if( ::PtInRect(&m_rcThumb, event.ptMouse) ) m_uThumbState |= UISTATE_HOT;
 				Invalidate();
 			}


### PR DESCRIPTION
原来的滚动条，当鼠标移动上去时，无论是否处于两边按钮范围内，都会触发按据的MOUSEMOVE消息。此版本修正了这个小问题。
